### PR TITLE
fix(adapters): honor $MB_PYTHON in cross-agent adapters (pipx/pyenv install break)

### DIFF
--- a/adapters/_lib_agents_md.sh
+++ b/adapters/_lib_agents_md.sh
@@ -46,14 +46,16 @@ mb_emit_rules_file() {
     return 1
   fi
 
-  if ! command -v python3 >/dev/null 2>&1; then
+  # Prefer the interpreter the CLI handed us (MB_PYTHON); fall back to python3.
+  local py="${MB_PYTHON:-python3}"
+  if ! command -v "$py" >/dev/null 2>&1; then
     cat "$rules_file"
     return 0
   fi
 
   TARGET_RULES_FILE="$rules_file" \
   MB_RULE_LANGUAGE="$lang" \
-  python3 <<'PYEOF'
+  "$py" <<'PYEOF'
 from pathlib import Path
 import os
 import re

--- a/adapters/_lib_pi_global.sh
+++ b/adapters/_lib_pi_global.sh
@@ -98,7 +98,7 @@ install_pi_settings_skill() {
   local settings_file="$PI_AGENT_DIR/settings.json"
   mkdir -p "$PI_AGENT_DIR"
 
-  SETTINGS_FILE="$settings_file" python3 <<'PYEOF'
+  SETTINGS_FILE="$settings_file" "${MB_PYTHON:-python3}" <<'PYEOF'
 import json
 import os
 from pathlib import Path

--- a/adapters/cursor.sh
+++ b/adapters/cursor.sh
@@ -82,8 +82,12 @@ EVENT_BINDINGS=(
 )
 
 run_texttool() {
+  # Use the interpreter that owns the memory_bank_skill package (exported by the
+  # CLI as MB_PYTHON). A bare `python3` resolves to whatever is first on PATH —
+  # under pipx/pyenv that is NOT the venv holding the package, so the import of
+  # memory_bank_skill._texttools fails. Fall back to python3 for git checkouts.
   PYTHONPATH="$SKILL_DIR${PYTHONPATH:+:$PYTHONPATH}" \
-    python3 -m memory_bank_skill._texttools "$@"
+    "${MB_PYTHON:-python3}" -m memory_bank_skill._texttools "$@"
 }
 
 language_rule_full() {

--- a/tests/pytest/test_cli.py
+++ b/tests/pytest/test_cli.py
@@ -578,6 +578,83 @@ def test_install_sh_routes_python_through_mb_python(tmp_path):
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
+def test_cross_agent_adapters_route_python_through_mb_python(tmp_path):
+    """Cross-agent adapters (e.g. cursor.sh ``run_texttool``) must run Python
+    through ``$MB_PYTHON``, not a bare ``python3``.
+
+    Regression for the pipx/pyenv break: ``memory_bank_skill`` lives only in the
+    interpreter the CLI hands the installer via ``MB_PYTHON``. A bare ``python3``
+    resolves to whatever is first on PATH (under pyenv: a shim without the
+    package), so ``python3 -m memory_bank_skill._texttools`` raises
+    ``ModuleNotFoundError``. cursor.sh swallows that error (``|| true``), so the
+    install still returns 0 but silently skips AGENTS.md localization. We poison
+    the bare ``python3`` so any package import through it fails loudly, and
+    assert the install never falls back to it.
+    """
+    sandbox = tmp_path / "home"
+    sandbox.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+
+    # MB_PYTHON: the real interpreter that owns the package (this test's python),
+    # with the repo on PYTHONPATH so `-m memory_bank_skill...` resolves.
+    real_py = tmp_path / "mb-python.sh"
+    real_py.write_text(
+        f'#!/usr/bin/env bash\n'
+        f'exec env PYTHONPATH="{REPO_ROOT}${{PYTHONPATH:+:$PYTHONPATH}}" '
+        f'"{sys.executable}" "$@"\n'
+    )
+    real_py.chmod(0o755)
+
+    # Poisoned bare python3: fails on any memory_bank_skill import, else delegates.
+    poison_dir = tmp_path / "poison"
+    poison_dir.mkdir()
+    bare_py = poison_dir / "python3"
+    bare_py.write_text(
+        '#!/usr/bin/env bash\n'
+        'case " $* " in\n'
+        '  *memory_bank_skill*) echo "bare python3 used for memory_bank_skill" >&2; exit 1 ;;\n'
+        'esac\n'
+        f'exec "{sys.executable}" "$@"\n'
+    )
+    bare_py.chmod(0o755)
+
+    env = {
+        "HOME": str(sandbox),
+        "PATH": f"{poison_dir}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        "MB_PYTHON": str(real_py),
+    }
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "install.sh"),
+            "--non-interactive",
+            "--clients",
+            "claude-code,cursor",
+            "--project-root",
+            str(project),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"install.sh failed (rc={result.returncode})\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "No module named 'memory_bank_skill'" not in combined, (
+        "a cross-agent adapter imported memory_bank_skill through a bare "
+        f"python3 instead of MB_PYTHON\n{combined}"
+    )
+    assert "bare python3 used for memory_bank_skill" not in combined, (
+        "a cross-agent adapter ran `python3 -m memory_bank_skill` through the "
+        f"bare PATH interpreter instead of MB_PYTHON\n{combined}"
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
 def test_uninstall_non_interactive_flag_works_without_stdin(tmp_path):
     sandbox = tmp_path / "home"
     sandbox.mkdir()


### PR DESCRIPTION
Fixes #4

## Summary

Cross-agent adapters run during `memory-bank install` call a **bare `python3`**, ignoring the `$MB_PYTHON` interpreter the CLI exports (`cli.py`: `env["MB_PYTHON"] = sys.executable`).

On a **pipx + pyenv** setup this breaks: `memory_bank_skill` is importable only from the pipx venv that owns it, but a bare `python3` resolves to the pyenv shim on `PATH`, which cannot import the package.

The most visible symptom is in `adapters/cursor.sh` → `run_texttool()`:

```
python3 -m memory_bank_skill._texttools "$@"
```

→ `ModuleNotFoundError: No module named 'memory_bank_skill'`.

Because cursor.sh swallows the failure (`|| true`), the install still exits `0` but **silently skips** AGENTS.md language-localization and marker-stripping. (On older CLI builds that did not yet export `MB_PYTHON`, the same class of bug aborted the install outright at the Rules step.)

This is exactly the failure mode the existing `test_install_sh_routes_python_through_mb_python` guards against — it just wasn't covered for the adapter code paths.

## Fix

Route every install-time adapter Python call through `${MB_PYTHON:-python3}` (fallback preserved for plain `bash install.sh` from a git checkout):

- `adapters/cursor.sh` — `run_texttool()`
- `adapters/_lib_agents_md.sh` — `mb_emit_rules_file()` (both the `command -v` guard and the heredoc interpreter)
- `adapters/_lib_pi_global.sh` — `install_pi_settings_skill()`

## Test

Adds `test_cross_agent_adapters_route_python_through_mb_python`, which runs `install.sh --non-interactive --clients claude-code,cursor` with:

- `MB_PYTHON` → a wrapper around the real interpreter (with the repo on `PYTHONPATH`), and
- a **poisoned bare `python3`** first on `PATH` that exits non-zero on any `memory_bank_skill` import.

It asserts the install completes and never falls back to the bare interpreter.

## Verification

- New test **fails on pre-fix** `cursor.sh`, **passes after** the fix.
- Reproduced end-to-end with a fake `python3` that fails only on `memory_bank_skill` imports: unpatched emits `No module named 'memory_bank_skill'`; patched does not.
- Full suite: `tests/pytest/test_cli.py` → **41 passed**.

## Note (out of scope, FYI)

Many **runtime** scripts (`hooks/`, `scripts/mb-*.sh`) also call bare `python3 -m memory_bank_skill.*`. Since `MB_PYTHON` is only set during install, a pipx-only install (without the package also in the system `python3`) likely can't import the package at runtime either. That's a broader design question (persist the chosen interpreter for runtime, or document `pip install` vs `pipx`) and is intentionally left out of this PR, which focuses on the install path + the existing `MB_PYTHON` contract.
