### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #5)

### DIFF
--- a/commands/changelog.md
+++ b/commands/changelog.md
@@ -1,7 +1,7 @@
 ---
 description: Generate a changelog from commits
 allowed-tools: [Bash, Read, Edit]
-argument-hint: [version]
+argument-hint: "[version]"
 ---
 
 1. Detect the latest tag: `git describe --tags --abbrev=0 2>/dev/null || echo "start"`

--- a/commands/commit.md
+++ b/commands/commit.md
@@ -1,7 +1,7 @@
 ---
 description: Review staged changes and create a commit
 allowed-tools: [Bash, Read]
-argument-hint: [message-override]
+argument-hint: "[message-override]"
 ---
 
 ## 0. Pre-flight safety checks

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -1,7 +1,7 @@
 ---
 description: Create a PR from the current branch
 allowed-tools: [Bash, Read]
-argument-hint: [title-override]
+argument-hint: "[title-override]"
 ---
 
 ## 0. Pre-flight checks

--- a/commands/security-review.md
+++ b/commands/security-review.md
@@ -1,7 +1,7 @@
 ---
 description: Scan code for security vulnerabilities (OWASP, secrets, dependencies)
 allowed-tools: [Read, Glob, Grep, Bash]
-argument-hint: [scope-path]
+argument-hint: "[scope-path]"
 ---
 
 # Security Review: $ARGUMENTS

--- a/commands/test.md
+++ b/commands/test.md
@@ -1,7 +1,7 @@
 ---
 description: Run tests, analyze failures, and propose fixes
 allowed-tools: [Bash, Read, Glob, Grep, Task]
-argument-hint: [test-filter]
+argument-hint: "[test-filter]"
 ---
 
 ## 1. Delegate execution to `mb-test-runner`

--- a/references/command-template.md
+++ b/references/command-template.md
@@ -74,7 +74,7 @@ Key traits: one-line description, 2-tool whitelist, 5-step body, no arguments â†
 ---
 description: Run tests, analyze failures, and propose fixes
 allowed-tools: [Bash, Read, Glob, Grep]
-argument-hint: [test-filter]
+argument-hint: "[test-filter]"
 ---
 
 # Test: $ARGUMENTS


### PR DESCRIPTION
Closes #5.

## Summary

Purely mechanical single-character transform to 6 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (6)

- `commands/pr.md`
- `commands/changelog.md`
- `commands/commit.md`
- `commands/security-review.md`
- `references/command-template.md`
- `commands/test.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
